### PR TITLE
Replace `typing.Iterable` with `collections.abc.Iterable`

### DIFF
--- a/editor/initial_code/python_3.tmpl
+++ b/editor/initial_code/python_3.tmpl
@@ -1,5 +1,5 @@
 {% comment %}New initial code template{% endcomment %}
-{% block env %}from typing import Iterable{% endblock env %}
+{% block env %}from collections.abc import Iterable{% endblock env %}
 
 {% block start %}
 def frequency_sort(items: list[str|int]) -> Iterable[str|int]:


### PR DESCRIPTION
Import `collections.abc.Iterable` because `typing.Iterable` [deprecated since version 3.9](https://docs.python.org/3.12/library/typing.html#typing.Iterable).